### PR TITLE
publish Windows binaries to github

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,10 +3,11 @@ buildDebSbuild(
     repos: ['devTools'],
     defaultRunLintian: true,
     defaultRunPythonChecks: true,
+    releaseFilesFilter: "**/*.deb, **/*.zip",
     customBuildSteps: {
         stage("Build exe") {
             sh 'docker run -t -v $DEV_VOLUME -w $PWD/$PROJECT_SUBDIR tobix/pywine bash -c "./Build.sh clean &&  ./Build.sh windows"'
-            sh 'wbdev root bash -c "cd $PROJECT_SUBDIR/dist/windows && zip -r wb-modbus-device-editor.zip ./wb-modbus-device-editor/"'
+            sh 'wbdev root bash -c "cd $PROJECT_SUBDIR/dist/windows && zip -r wb-modbus-device-editor-windows.zip ./wb-modbus-device-editor/"'
             sh "cp -r $PROJECT_SUBDIR/dist/ $RESULT_SUBDIR/"
             archiveArtifacts artifacts: "$RESULT_SUBDIR/dist/windows/*.zip"
         }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-modbus-device-editor (1.2.1) stable; urgency=medium
+
+  * Publish Windows binaries to GitHub, no functional changes
+
+ -- Nikita Maslov <nikita.maslov@wirenboard.com>  Tue, 09 Apr 2024 16:04:24 +0500
+
 wb-modbus-device-editor (1.2.0) stable; urgency=medium
 
   * Fix interface freeze


### PR DESCRIPTION
Использует новый пайплайн buildDebSbuild.

Тут же поправил имя артефакта с бинарниками для Windows, чтобы можно было отличить от архива с исходниками