### PR TITLE
Win build fixup

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,7 +6,7 @@ buildDebSbuild(
     releaseFilesFilter: "**/*.deb, **/*.zip",
     customBuildSteps: {
         stage("Build exe") {
-            sh 'docker run -t -v $DEV_VOLUME -w $PWD/$PROJECT_SUBDIR tobix/pywine bash -c "./Build.sh clean &&  ./Build.sh windows"'
+            sh 'docker run -t -v $DEV_VOLUME -w $PWD/$PROJECT_SUBDIR tobix/pywine:3.10 bash -c "./Build.sh clean &&  ./Build.sh windows"'
             sh 'wbdev root bash -c "cd $PROJECT_SUBDIR/dist/windows && zip -r wb-modbus-device-editor-windows.zip ./wb-modbus-device-editor/"'
             sh "cp -r $PROJECT_SUBDIR/dist/ $RESULT_SUBDIR/"
             archiveArtifacts artifacts: "$RESULT_SUBDIR/dist/windows/*.zip"


### PR DESCRIPTION
Поправила сборку под win. Оказывается в контейнере теперь все стало собираться под питон 3.12, понизила до 3.10 - дефендер больше не ругается