### PR TITLE
Remove filter when tar unpacking

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wb-modbus-device-editor (1.2.5) stable; urgency=medium
+
+  * Remove filer on tar unpacking
+
+ -- Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Tue, 07 May 2024 12:08:23 +0300
+
 wb-modbus-device-editor (1.2.4) stable; urgency=medium
 
   * Fix pyserial dependence

--- a/wb_modbus_device_editor/template_manager.py
+++ b/wb_modbus_device_editor/template_manager.py
@@ -152,15 +152,7 @@ class TemplateManager:
         source_raw = requests.get(tarball_url, timeout=1, stream=True)
         source_tar = tarfile.open(fileobj=source_raw.raw, mode="r|gz")
 
-        # https://docs.python.org/3.9/library/tarfile.html#tarfile.TarFile.extractall
-        if semantic_version.Version(platform.python_version()) < semantic_version.Version("3.9.17"):
-            source_tar.extractall(path=templates_dir, members=self._get_templates_from_tar(source_tar))
-        else:
-            source_tar.extractall(
-                path=templates_dir,
-                members=self._get_templates_from_tar(source_tar),
-                filter="data",
-            )
+        source_tar.extractall(path=templates_dir, members=self._get_templates_from_tar(source_tar))
 
         template_loader = jinja2.FileSystemLoader(searchpath=templates_dir)
         template_env = jinja2.Environment(loader=template_loader)


### PR DESCRIPTION
Аргумент filter завезли одновременно в несколько минорных версий питона, и в каждом случае разное значение фикса. В 3.9 с версии 3.9.17, в 10 с 3.10.12 и тд. Проще уже выкинуть это чем городить столько проверок на версию.