### PR TITLE
Do not use templates that have parameters with the same id

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,14 @@
+wb-modbus-device-editor (1.4.2) stable; urgency=medium
+
+  * Do not use templates that have parameters with the same id
+
+ --  Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Thu, 03 Oct 2024 13:23:51 +0300
+
 wb-modbus-device-editor (1.4.1) stable; urgency=medium
 
   * Fix parameters write
 
- --  Ekaterina Volkova <ekateluv@ekateluv>  Fri, 21 Jun 2024 15:57:25 +0300
+ --  Ekaterina Volkova <ekaterina.volkova@wirenboard.com>  Fri, 21 Jun 2024 15:57:25 +0300
 
 wb-modbus-device-editor (1.4.0) stable; urgency=medium
 

--- a/wb_modbus_device_editor/template_manager.py
+++ b/wb_modbus_device_editor/template_manager.py
@@ -11,6 +11,10 @@ import requests
 import semantic_version
 
 
+class TemplateException(Exception):
+    pass
+
+
 class Template:
     def __init__(self, template_path, full_read: bool):
         self._template_path = template_path
@@ -39,7 +43,16 @@ class Template:
         if source == None or isinstance(source, dict):
             return source
 
-        return {item.pop("id"): item for item in source}
+        result = {}
+        for item in source:
+            if result.get(item["id"]) is not None:
+                raise TemplateException(
+                    "К сожалению, в настоящее время использование этого шаблона не поддерживается."
+                )
+            id = item.pop("id")
+            result[id] = item
+
+        return result
 
     def _get_template_full_info(self, template_path):
         with open(template_path, encoding="utf-8") as json_template:


### PR DESCRIPTION
SOFT-4298
решили не чинить, просто вывести читаемую ошибку
![изображение](https://github.com/user-attachments/assets/8627bfb7-e3a5-4335-beed-10984225ed06)
